### PR TITLE
Fix pip version syntax in YAML (use == instead of =)

### DIFF
--- a/project_1/environment.yml
+++ b/project_1/environment.yml
@@ -8,12 +8,13 @@ dependencies:
 - ipywidgets
 - pip
 - pip:
-  - torch=2.7.0
-  - transformers=4.52.0
-  - datasets=3.6.0
-  - evaluate=0.4.3
-  - tiktoken=0.9.0
-  - accelerate=1.7.0
-  - sentencepiece=0.2.0
-  - ipython=9.2.0
-  - huggingface_hub=0.31.4
+  - torch==2.7.0
+  - transformers==4.52.0
+  - datasets==3.6.0
+  - evaluate==0.4.3
+  - tiktoken==0.9.0
+  - accelerate==1.7.0
+  - sentencepiece==0.2.0
+  - ipython==9.2.0
+  - huggingface_hub==0.31.4
+


### PR DESCRIPTION
The pip section in environment.yml used single = for versions, which is invalid.
Changed all version specifiers to == so pip can install correctly.
