### PR TITLE
Update ask_the_web_agent.ipynb

### DIFF
--- a/project_3/ask_the_web_agent.ipynb
+++ b/project_3/ask_the_web_agent.ipynb
@@ -451,7 +451,7 @@
     "#   3. Wrap it with the @tool decorator to make it available to LangChain.\n",
     "\n",
     "\n",
-    "from duckduckgo_search import DDGS\n",
+    "from ddgs import DDGS\n",
     "from langchain.tools import tool\n",
     "\n",
     "d\"\"\"\n",


### PR DESCRIPTION
switched to the new duckduckgo package because the deprecated one was returning empty results list