### PR TITLE
Update dependencies to to langchain 1.0.0 in project_4

### DIFF
--- a/project_4/deep_research.ipynb
+++ b/project_4/deep_research.ipynb
@@ -468,19 +468,15 @@
    "outputs": [],
    "source": [
     "from ddgs import DDGS\n",
-    "from langchain.tools import Tool\n",
+    "from langchain.tools import tool\n",
     "\n",
+    "@tool(\"DuckDuckGo Search\")\n",
     "def ddg_search(query: str, k: int = 5) -> str:\n",
+    "    \"Search the public web. Input: a plain English query. Returns: concatenated snippets.\"\n",
     "    # Use DDGS to run a simple web search and return joined snippets.\n",
-    "    \"\"\"\n",
-    "    YOUR CODE HERE (~6 lines of code)\n",
-    "    \"\"\"\n",
-    "\n",
-    "search_tool = Tool(\n",
-    "    name=\"DuckDuckGo Search\",\n",
-    "    func=ddg_search,\n",
-    "    description=\"Search the public web. Input: a plain English query. Returns: concatenated snippets.\"\n",
-    ")\n"
+    "    ###\n",
+    "    # YOUR CODE HERE (~6 lines of code)\n",
+    "    ###\n"
    ]
   },
   {
@@ -490,8 +486,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.agents import initialize_agent, AgentType\n",
-    "from langchain_community.chat_models import ChatOllama\n",
+    "from langchain.agents import create_agent\n",
+    "from langchain_ollama import ChatOllama\n",
     "\n",
     "MODEL = \"deepseek-r1:8b\"\n",
     "question = \"What are the best resources to learn machine learning in 2025?\"\n",

--- a/project_4/environment.yaml
+++ b/project_4/environment.yaml
@@ -3,14 +3,16 @@ channels:
   - defaults
 dependencies:
   - python=3.11
-  - pip:
+  - pip
       - torch==2.9.0
       - transformers==4.57.1
-      - ollama-python==0.1.2
       - ddgs==9.4.0
-      - langchain-openai==0.3.27
-      - langchain-community==0.3.27
-      - openai==1.86.0
-      - langchain==0.3.26
+      - langchain==1.0.0
+      - langchain-classic==1.0.0
+      - langchain-community==0.4
+      - langchain-core==1.0.0
+      - langchain-ollama==1.0.0
+      - langchain-openai==1.0.0
+      - openai==2.5.0
       - jupyter==1.1.1
       - ipykernel==6.29.5


### PR DESCRIPTION
* ollama-python no longer needed, replaced by langchain-ollama
* use new langchain.tools.tool decorator for defining tools